### PR TITLE
Added support for logging cached session keys

### DIFF
--- a/src/main/java/net/sf/jsslkeylog/ClientKeyExchangeTransformer.java
+++ b/src/main/java/net/sf/jsslkeylog/ClientKeyExchangeTransformer.java
@@ -52,11 +52,18 @@ public class ClientKeyExchangeTransformer extends AbstractTransformer {
 						return;
 					}
 					if (lastAloadVar == -1 || handshakeContextVar == -1) throw new IllegalStateException();
-					
+
+					int masterSecretVar = lastAloadVar;
+
+					mv.visitVarInsn(ALOAD, handshakeContextVar);
+					mv.visitFieldInsn(GETFIELD, "sun/security/ssl/HandshakeContext", "handshakeSession", "Lsun/security/ssl/SSLSessionImpl;");
+					mv.visitVarInsn(ALOAD, masterSecretVar);
+					mv.visitMethodInsn(INVOKESTATIC, className, "$LogWriter$logSessionKey", "(Ljavax/net/ssl/SSLSession;Ljavax/crypto/SecretKey;)V", false);
+
 					mv.visitVarInsn(ALOAD, handshakeContextVar);
 					mv.visitFieldInsn(GETFIELD, "sun/security/ssl/HandshakeContext", "clientHelloRandom", "Lsun/security/ssl/RandomCookie;");
 					mv.visitFieldInsn(GETFIELD, "sun/security/ssl/RandomCookie", "randomBytes", "[B");
-					mv.visitVarInsn(ALOAD, lastAloadVar);
+					mv.visitVarInsn(ALOAD, masterSecretVar);
 					mv.visitVarInsn(ALOAD, handshakeContextVar);
 					mv.visitFieldInsn(GETFIELD, "sun/security/ssl/HandshakeContext", "conContext", "Lsun/security/ssl/TransportContext;");
 					mv.visitFieldInsn(GETFIELD, "sun/security/ssl/TransportContext", "transport", "Lsun/security/ssl/SSLTransport;");

--- a/src/main/java/net/sf/jsslkeylog/LogWriter.java
+++ b/src/main/java/net/sf/jsslkeylog/LogWriter.java
@@ -7,6 +7,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import javax.crypto.SecretKey;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 
 /**
@@ -32,6 +33,18 @@ public class LogWriter {
 		logLine("CLIENT_RANDOM " + hex(clientRandom) + " " + hex(masterSecret.getEncoded()),
 				conn == null ? null : conn.getLocalSocketAddress() + " -> " + conn.getRemoteSocketAddress());
 	}
+
+	/**
+	 * RSA Session-ID:4b8569d40aac2dba1fb8e1ad5260f1b310bd050515f3f14b59cf1bcc05e29bed
+	 * Master-Key
+	 * :6fd5bf0156d037cc7091bcd9c91b4d82ced2d78e4d76569d9b5b15f34c98c598d00ce80dd7b758094fded82ac166b9c8
+	 * @param session
+	 * @param masterSecret
+	 */
+	public static void logSessionKey(SSLSession session, SecretKey masterSecret) {
+		logLine("RSA Session-ID:" + hex(session.getId()) + " Master-Key:" + hex(masterSecret.getEncoded()), null);
+	}
+
 
 	public static void logTLS13KeyAgreement(SecretKey resultSecret, SecretKey inputSecret, PrivateKey inputPrivate, String algorithm, byte[] clientRandom, Object maybeConn) {
 		if (inputSecret != null) {


### PR DESCRIPTION
Some time ago I was doing a long debugging of REST/HTTPS client. Despite of capturing all the traffic, majority of the TLS connections was missing encryption keys. I have realised that it was because sometimes the keys are cached and reused for connections to the same server. Wireshark supports this as RSA Session master keys. This PR adds the necessary code instrumentation to capture these keys and expose them in Wireshark compatible format.